### PR TITLE
Add Crypto.Hash.Utils to exposed-modules

### DIFF
--- a/cryptohash.cabal
+++ b/cryptohash.cabal
@@ -71,8 +71,8 @@ Library
                      Crypto.Hash.Whirlpool
                      Crypto.MAC.HMAC
                      Crypto.MAC.SHA3
-  Other-modules:     Crypto.Hash.Utils
-                     Crypto.Hash.Utils.Cpu
+                     Crypto.Hash.Utils
+  Other-modules:     Crypto.Hash.Utils.Cpu
                      Crypto.Hash.Internal
   ghc-options:       -Wall -O2 -optc-O3 -fno-cse -fwarn-tabs
   C-sources:         cbits/sha1.c


### PR DESCRIPTION
Hi!

I'm currently struggling with doing something like:

``` haskell
toHex (hmac SHA256.hash 64)
```

with current set of public API of hs-cryptohash, since `toHex` is not exposed currently.

Thanks!
